### PR TITLE
replace `open(...).read()` with `read_bytes()`/`read_text()` from pathlib

### DIFF
--- a/showcert/processcert.py
+++ b/showcert/processcert.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+from pathlib import Path
 import sys
 
 from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_TEXT, load_certificate, \
@@ -42,7 +43,7 @@ def get_local_certs(CERT, insecure=False, password=None):
     if CERT == '-':
         rawcert = sys.stdin.read()
     else:        
-        rawcert = open(CERT, "rb").read()
+        rawcert = Path(CERT).read_bytes()
 
     mime = magic.from_buffer(rawcert, mime=True)
 

--- a/showcert/verifychain.py
+++ b/showcert/verifychain.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 from OpenSSL.crypto import X509Store, X509StoreContext
 import certifi
@@ -23,7 +25,7 @@ def verify_chain(chain, hostname=None, trusted_ca = None):
     # verify
     store = X509Store()
 
-    raw_ca = open(trusted_ca).read().rstrip().encode()
+    raw_ca = Path(trusted_ca).read_bytes().rstrip()
 
     for _ca in pem.parse(raw_ca):
         if isinstance(_ca, pem._object_types.Certificate):


### PR DESCRIPTION
This ensures files are automatically closed after reading, preventing resource leaks from unclosed file handles.

In CPython this is currently not a problem but it might leave open file descriptors in other Python implementations. Also with all the changes in CPython (JIT, free threading), this might lead to leaks even in CPython.