### PR TITLE
add optional support for "file-magic"

### DIFF
--- a/showcert/processcert.py
+++ b/showcert/processcert.py
@@ -45,7 +45,7 @@ def get_local_certs(CERT, insecure=False, password=None):
     else:        
         rawcert = Path(CERT).read_bytes()
 
-    mime = magic.from_buffer(rawcert, mime=True)
+    mime = _detect_mimetype(rawcert)
 
     if mime.startswith("text/") or "BEGIN CERTIFICATE" in str(rawcert):
         # default simple PEM part
@@ -62,6 +62,16 @@ def get_local_certs(CERT, insecure=False, password=None):
         if addl:
             certs.extend(crypto_cert_to_pyopenssl(c) for c in addl)
         return certs
+
+
+def _detect_mimetype(file_contents: bytes | str) -> str:
+    if hasattr(magic, "from_buffer"):
+        # https://pypi.org/project/python-magic/
+        return magic.from_buffer(file_contents, mime=True)
+    # https://pypi.org/project/file-magic/
+    _file_magic = magic.detect_from_content(file_contents)
+    return _file_magic.mime_type
+
 
 def get_days_left(crt):
     nafter = datetime.strptime(crt.get_notAfter().decode(), '%Y%m%d%H%M%SZ')

--- a/showcert/processcert.py
+++ b/showcert/processcert.py
@@ -41,7 +41,7 @@ def crypto_cert_to_pyopenssl(cert: cryptography_x509.Certificate) -> X509:
 
 def get_local_certs(CERT, insecure=False, password=None):
     if CERT == '-':
-        rawcert = sys.stdin.read()
+        rawcert = sys.stdin.buffer.read()
     else:        
         rawcert = Path(CERT).read_bytes()
 
@@ -64,7 +64,7 @@ def get_local_certs(CERT, insecure=False, password=None):
         return certs
 
 
-def _detect_mimetype(file_contents: bytes | str) -> str:
+def _detect_mimetype(file_contents: bytes) -> str:
     if hasattr(magic, "from_buffer"):
         # https://pypi.org/project/python-magic/
         return magic.from_buffer(file_contents, mime=True)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -44,9 +44,13 @@ class TestShowcertLocal():
         rc = process_cert(CERT=self.snakeoil, output='no', insecure=True)
         assert(rc == 0)
 
-    def test_stdin(self):        
-        with open(self.ca_certs[0], "r") as f:  # Read the certificate file
+    def test_stdin(self, monkeypatch):
+        with open(self.ca_certs[0], "rb") as f:  # Read the certificate file
             mock_input = f.read()
-        with mock.patch("sys.stdin", io.StringIO(mock_input)):
-            rc = process_cert(CERT='-')
-            assert rc == 0
+
+        mock_stdin = mock.Mock()
+        mock_stdin.buffer = io.BytesIO(mock_input)
+        monkeypatch.setattr("sys.stdin", mock_stdin)
+
+        rc = process_cert(CERT='-')
+        assert rc == 0


### PR DESCRIPTION
There are multiple Python packages for the "libmagic" library. Unfortunately, some of them use the same Python package name ("magic") and can not be installed in parallel.

This code adds support for the "file-magic" pypi package as a fallback when "python-magic" is not installed. Unfortunately `pyproject.toml` does not provide a way to express a XOR dependency so regular users will always use "python-magic". However this change enables Linux distributions like Fedora to simply patch `pyproject.toml`.

In particular, Fedora's file manager "dnf" has an indirect dependency on `python3-file-magic` so `python-magic` can not be installed. Not sure if you want to take that patch but it would certainly simplify packaging for Fedora. However I can also just carry this change as a downstream patch.